### PR TITLE
encode nulls, not undefineds

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,20 @@
 
 Javascript implementation of the [SSB binary field encodings] spec.
 
-The spec only has one type of **nil**, but JavaScript has two: `null` and `undefined`. ssb-bfe will treat these two values in a way that mirrors what JSON.stringify does:
+The spec only has one type of **nil**, but JavaScript has two: `null` and
+`undefined`. ssb-bfe will treat these two values in a way that mirrors what
+JSON.stringify does:
 
-- BFE Encoding an **object** with a `null` field becomes an object with the **nil** marker
+- BFE Encoding an **object** with a `null` field becomes an object with the
+**nil** marker
   - Similar to `JSON.stringify({a: null}) === '{"a": null}'`
-- BFE Encoding an **array** with a `null` element becomes an array with the **nil** marker
+- BFE Encoding an **array** with a `null` element becomes an array with the
+**nil** marker
   - Similar to `JSON.stringify([null]) === '[null]'`
 - BFE Encoding an **object** with a `undefined` field will **omit** that field
   - Similar to `JSON.stringify({a: undefined}) === '{}'`
-- BFE Encoding an **array** with an `undefined` element becomes an array with the **nil** marker
+- BFE Encoding an **array** with an `undefined` element becomes an array with
+the **nil** marker
   - Similar to `JSON.stringify([undefined]) === '[null]'`
 
 ## API

--- a/README.md
+++ b/README.md
@@ -2,11 +2,16 @@
 
 Javascript implementation of the [SSB binary field encodings] spec.
 
-For encoding, the *null* message value can be ambiguous as it depends
-on the feed format we encode for. Secondly the specification allows an
-empty value to be encoded as a value type. Javascript has two ways to
-express the lack of a value: null and undefined. For value types we
-will use undefined.
+The spec only has one type of **nil**, but JavaScript has two: `null` and `undefined`. ssb-bfe will treat these two values in a way that mirrors what JSON.stringify does:
+
+- BFE Encoding an **object** with a `null` field becomes an object with the **nil** marker
+  - Similar to `JSON.stringify({a: null}) === '{"a": null}'`
+- BFE Encoding an **array** with a `null` element becomes an array with the **nil** marker
+  - Similar to `JSON.stringify([null]) === '[null]'`
+- BFE Encoding an **object** with a `undefined` field will **omit** that field
+  - Similar to `JSON.stringify({a: undefined}) === '{}'`
+- BFE Encoding an **array** with an `undefined` element becomes an array with the **nil** marker
+  - Similar to `JSON.stringify([undefined]) === '[null]'`
 
 ## API
 

--- a/index.js
+++ b/index.js
@@ -86,20 +86,20 @@ const encoder = {
 
 function encode(feedformat, value) {
   if (Array.isArray(value)) {
-    return value.map((x) => encode(feedformat, x) || NULL_TYPE)
+    return value.map((x) => {
+      const y = encode(feedformat, x)
+      if (y === undefined) return NULL_TYPE
+      else return y
+    })
   } else if (value === undefined) {
     return undefined
   } else if (value === null) {
     return NULL_TYPE
-  } else if (
-    !Buffer.isBuffer(value) &&
-    typeof value === 'object' &&
-    value !== null
-  ) {
+  } else if (!Buffer.isBuffer(value) && typeof value === 'object') {
     const converted = {}
     for (var k in value) {
-      const encoded = encode(feedformat, value[k])
-      if (encoded) converted[k] = encoded
+      const y = encode(feedformat, value[k])
+      if (y !== undefined) converted[k] = y
     }
     return converted
   } else if (typeof value === 'string') {

--- a/test/basic.js
+++ b/test/basic.js
@@ -10,8 +10,10 @@ tape('encode/decode basic types', function (t) {
     {
       a: 1,
       b: 'string',
+      c: 0,
     },
     100,
+    0,
   ]
 
   const encoded = bfe.encode('classic', values)
@@ -25,7 +27,9 @@ tape('encode/decode basic types', function (t) {
     '0600',
     'object string values encoded'
   )
+  t.equal(encoded[4]['c'], 0, 'falsy numbers as an object field')
   t.equal(encoded[5], 100, 'numbers not encoded')
+  t.equal(encoded[6], 0, 'falsy number as an array item')
   const decoded = bfe.decode(encoded)
   t.deepEqual(decoded, values, 'properly decoded')
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -2,10 +2,10 @@ const tape = require('tape')
 const bfe = require('../')
 
 tape('encode/decode basic types', function (t) {
-  let values = [
+  const values = [
     true,
     false,
-    undefined,
+    null,
     'this is a string',
     {
       a: 1,
@@ -17,7 +17,7 @@ tape('encode/decode basic types', function (t) {
   const encoded = bfe.encode('classic', values)
   t.equal(encoded[0].toString('hex'), '060101', 'true')
   t.equal(encoded[1].toString('hex'), '060100', 'false')
-  t.equal(encoded[2].toString('hex'), '0602', 'undefined')
+  t.equal(encoded[2].toString('hex'), '0602', 'null')
   t.equal(encoded[3].slice(0, 2).toString('hex'), '0600', 'string')
   t.equal(encoded[4]['a'], 1, 'numbers in object not encoded')
   t.equal(
@@ -29,6 +29,29 @@ tape('encode/decode basic types', function (t) {
   const decoded = bfe.decode(encoded)
   t.deepEqual(decoded, values, 'properly decoded')
 
+  t.end()
+})
+
+tape('undefined in an object disappears when encoded', function (t) {
+  const obj = { a: 'alice', b: undefined, c: 'carla' }
+  const encoded = bfe.encode('classic', obj)
+  t.deepEquals(Object.keys(encoded), ['a', 'c'], 'key "b" is not found')
+  t.equal(encoded.a.slice(0, 2).toString('hex'), '0600', '"a" is a string')
+  t.notok(encoded.b, 'field "b" is not found')
+  t.equal(encoded.c.slice(0, 2).toString('hex'), '0600', '"c" is a string')
+  t.end()
+})
+
+tape('undefined in an array is converted to null when encoded', function (t) {
+  const arr = ['alice', undefined, 'carla']
+  const encoded = bfe.encode('classic', arr)
+  t.equals(encoded.length, 3, 'length remains the same')
+  t.equals(encoded[0].slice(0, 2).toString('hex'), '0600', '1st is a string')
+  t.equals(encoded[1].slice(0, 2).toString('hex'), '0602', '2nd is null')
+  t.equals(encoded[2].slice(0, 2).toString('hex'), '0600', '3rd is a string')
+
+  const decoded = bfe.decode(encoded)
+  t.deepEquals(decoded, ['alice', null, 'carla'])
   t.end()
 })
 
@@ -57,12 +80,7 @@ tape('encode/decode bendy butt', function (t) {
   const encoded = bfe.encodeBendyButt(values)
   t.equal(encoded[0].slice(0, 2).toString('hex'), '0003', 'bendy feed')
   t.equal(encoded[1].slice(0, 2).toString('hex'), '0104', 'bendy msg')
-  const nullBuffer = Buffer.concat([
-    Buffer.from([1]),
-    Buffer.from([4]),
-    Buffer.alloc(32),
-  ])
-  t.equal(encoded[2].compare(nullBuffer, 0, 32 + 2), 0, 'bendy null msg')
+  t.equal(encoded[2].toString('hex'), '0602', 'null')
   const decoded = bfe.decode(encoded)
   t.deepEqual(decoded, values, 'properly decoded')
   t.end()
@@ -79,12 +97,7 @@ tape('encode/decode classic', function (t) {
   const encoded = bfe.encodeClassic(values)
   t.equal(encoded[0].slice(0, 2).toString('hex'), '0000', 'classic feed')
   t.equal(encoded[1].slice(0, 2).toString('hex'), '0100', 'classic msg')
-  const nullBuffer = Buffer.concat([
-    Buffer.from([1]),
-    Buffer.from([0]),
-    Buffer.alloc(32),
-  ])
-  t.equal(encoded[2].compare(nullBuffer, 0, 32 + 2), 0, 'classic null msg')
+  t.equal(encoded[2].toString('hex'), '0602', 'null')
   t.equal(Buffer.isBuffer(encoded[3]), true, 'classic signature')
   const decoded = bfe.decode(encoded)
   t.deepEqual(decoded, values, 'properly decoded')


### PR DESCRIPTION
This PR is ready and works, but is pending on *design approval* from multiple stakeholders.

The primary change here is how null and undefined are treated. 

**null:**

`null` in JS is always converted to 0x0602 because we mirror JSON.stringify's behavior

- `JSON.stringify({a:null})` == `{"a":null}`
- `JSON.stringify([null])` == `[null]`

**undefined:**

`undefined` is a silent alternative to null. In objects, it gets omitted, but in arrays, it is converted to a null, to preserve the array length. See how JSON.stringify behaves:

- `JSON.stringify({a:undefined})` == `{}`
- `JSON.stringify([undefined])` == `[null]`