### PR TITLE
test that buffers can be encoded/decoded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 node_modules
+pnpm-lock.yaml
+.nyc_output
+coverage

--- a/index.js
+++ b/index.js
@@ -220,7 +220,7 @@ function decode(input) {
     else if (t.equals(BLOB_T)) return decoder.blob(input)
     else if (t.equals(BOX_T)) return decoder.box(input)
     else if (tf.equals(SIGNATURE_TF)) return decoder.signature(input)
-    else return input.toString('base64')
+    else return input
   } else if (typeof input === 'object' && input !== null) {
     const output = {}
     for (let key in input) {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "main": "index.js",
   "devDependencies": {
     "husky": "^4.3.0",
+    "nyc": "^15.1.0",
     "prettier": "^2.1.2",
     "pretty-quick": "^3.1.0",
     "tap-bail": "^1.0.0",
@@ -18,6 +19,7 @@
   },
   "scripts": {
     "test": "tape test/*.js | tap-bail | tap-spec",
+    "coverage": "nyc --reporter=lcov npm test",
     "format-code": "prettier --write \"*.js\" \"test/*.js\"",
     "format-code-staged": "pretty-quick --staged --pattern \"*.js\" --pattern \"test/*.js\""
   },

--- a/test/basic.js
+++ b/test/basic.js
@@ -13,6 +13,7 @@ tape('encode/decode basic types', function (t) {
       c: 0,
     },
     100,
+    Buffer.from([3, 2, 1]),
     0,
   ]
 
@@ -29,7 +30,8 @@ tape('encode/decode basic types', function (t) {
   )
   t.equal(encoded[4]['c'], 0, 'falsy numbers as an object field')
   t.equal(encoded[5], 100, 'numbers not encoded')
-  t.equal(encoded[6], 0, 'falsy number as an array item')
+  t.equal(encoded[6].toString('hex'), '030201', 'buffer untouched')
+  t.equal(encoded[7], 0, 'falsy number as an array item')
   const decoded = bfe.decode(encoded)
   t.deepEqual(decoded, values, 'properly decoded')
 


### PR DESCRIPTION
1st test :x:, 2nd fix :heavy_check_mark: 

Relevant discussion: https://github.com/ssb-ngi-pointer/ssb-meta-feeds/pull/10#discussion_r671032682