### PR TITLE
Envelope spec compat

### DIFF
--- a/index.js
+++ b/index.js
@@ -233,7 +233,21 @@ function decode(input) {
   else return input
 }
 
+function convertNilForEnvelopeSpec(msgTFD, feedTFD) {
+  if (msgTFD.equals(NIL_TFD)) {
+    const feedTF = feedTFD.slice(0, 2)
+    if (feedTF.equals(BENDYBT_FEED_TF))
+      return Buffer.concat([BENDYBT_MSG_TF, Buffer.alloc(32)])
+    else if (feedTF.equals(GABBYGR_FEED_TF))
+      return Buffer.concat([GABBYGR_MSG_TF, Buffer.alloc(32)])
+    else
+      return Buffer.concat([CLASSIC_MSG_TF, Buffer.alloc(32)])
+  } else
+    return msgTFD
+}
+
 module.exports = {
   encode,
   decode,
+  convertNilForEnvelopeSpec
 }

--- a/test/envelope.js
+++ b/test/envelope.js
@@ -13,5 +13,11 @@ tape('nil envelope', function (t) {
   t.equal(classicNull.slice(0,2).toString('hex'), '0100', 'classic msg')
   t.ok(classicNull.slice(2).equals(Buffer.alloc(32)), 'ends with 32 zeros')
   t.equal(classicNull.length, 32 + 2, 'length ok')
+
+  const msg = '%HZVnEzm0NgoSVfG0Hx4gMFbMMHhFvhJsG2zK/pijYII=.sha256'
+  const classicMsg = bfe.convertNilForEnvelopeSpec(bfe.encode(msg), bfe.encode(classicFeed))
+  t.equal(classicMsg.slice(0,2).toString('hex'), '0100', 'classic msg')
+  t.notOk(classicMsg.slice(2).equals(Buffer.alloc(32)), 'is not null')
+  t.equal(bfe.decode(classicMsg), msg, 'decodes back to the same')
   t.end()
 })

--- a/test/envelope.js
+++ b/test/envelope.js
@@ -1,0 +1,17 @@
+const tape = require('tape')
+const bfe = require('../')
+
+tape('nil envelope', function (t) {
+  const bbFeed = '@6CAxOI3f+LUOVrbAl0IemqiS7ATpQvr9Mdw9LC4+Uv0=.bbfeed-v1'
+  const bbNull = bfe.convertNilForEnvelopeSpec(bfe.encode(null), bfe.encode(bbFeed))
+  t.equal(bbNull.slice(0,2).toString('hex'), '0104', 'bendy msg')
+  t.ok(bbNull.slice(2).equals(Buffer.alloc(32)), 'ends with 32 zeros')
+  t.equal(bbNull.length, 32 + 2, 'length ok')
+
+  const classicFeed = '@6CAxOI3f+LUOVrbAl0IemqiS7ATpQvr9Mdw9LC4+Uv0=.ed25519'
+  const classicNull = bfe.convertNilForEnvelopeSpec(bfe.encode(null), bfe.encode(classicFeed))
+  t.equal(classicNull.slice(0,2).toString('hex'), '0100', 'classic msg')
+  t.ok(classicNull.slice(2).equals(Buffer.alloc(32)), 'ends with 32 zeros')
+  t.equal(classicNull.length, 32 + 2, 'length ok')
+  t.end()
+})


### PR DESCRIPTION
Envelope expects a 34 bytes message always when deriving, so in order to accommodate that this adds a helper function.