### PR TITLE
Add bfeTypes, use bfe.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,5 +32,26 @@ same.
 Takes an encoded value (such as the output from `encode`) and returns the
 decoded counterparts as JavaScript primitives.
 
+### bfeTypes()
+
+Returns the `bfe.json` object that can be used to look up information
+based on Type and Field. Example:
+
+```
+const { bfeTypes } = require('ssb-bfe')
+const classic_key_size = bfeTypes[0][0].data_length
+```
+
+### bfeNamedTypes()
+
+Returns the `bfe.json` object converted to a map where the keys are
+the type and format names. Example:
+
+```
+const { bfeNamedTypes } = require('ssb-bfe')
+const FEED = bfeNamedTypes['feed']
+const CLASSIC_FEED_TF = Buffer.from([FEED.code, FEED.formats['ssb/classic'].code])
+```
+
 [ssb binary field encodings]: https://github.com/ssb-ngi-pointer/ssb-binary-field-encodings-spec
 [TFD]: https://github.com/ssbc/envelope-spec/blob/master/encoding/tfk.md

--- a/bfe.json
+++ b/bfe.json
@@ -1,0 +1,62 @@
+[
+  {
+    "code": 0,
+    "type": "feed",
+    "formats": [
+      { "code": 0, "format": "ssb/classic",     "data_length": 32, "sigil": "@", "suffix": ".ed25519"   },
+      { "code": 1, "format": "ssb/gabby-grove", "data_length": 32, "sigil": "@", "suffix": ".ggfeed-v1" },
+      { "code": 2, "format": "bamboo",          "data_length": 32, "sigil": "@", "suffix": ".bamboo" },
+      { "code": 3, "format": "ssb/bendy-butt",  "data_length": 32, "sigil": "@", "suffix": ".bbfeed-v1" },
+      { "code": 4, "format": "ssb/fusion-identity", "data_length": 32, "sigil": "@", "suffix": ".fusion-v1" }
+    ]
+  },
+  {
+    "code": 1,
+    "type": "msg",
+    "formats": [
+      { "code": 0, "format": "ssb/classic",     "data_length": 32, "sigil": "%", "suffix": ".sha256"   },
+      { "code": 1, "format": "ssb/gabby-grove", "data_length": 32, "sigil": "%", "suffix": ".ggmsg-v1" },
+      { "code": 2, "format": "",                "data_length": 32, "sigil": "%", "suffix": ".cloaked" },
+      { "code": 3, "format": "bamboo",          "data_length": 64, "sigil": "%", "suffix": ".bamboo" },
+      { "code": 4, "format": "ssb/bendy-butt",  "data_length": 32, "sigil": "%", "suffix": ".bbmsg-v1" }
+    ]
+  },
+  {
+    "code": 2,
+    "type": "blob",
+    "formats": [
+      { "code": 0, "format": "ssb/classic", "data_length": 32, "sigil": "&", "suffix": ".sha256" }
+    ]
+  },
+  {
+    "code": 3,
+    "type": "diffie-hellman",
+    "formats": [
+      { "code": 0, "format": "curve25519", "key_length": 32 }
+    ]
+  },
+  {
+    "code": 4,
+    "type": "signature",
+    "formats": [
+      { "code": 0, "format": "ed25519", "signature_length": 64 }
+    ]
+  },
+  {
+    "code": 5,
+    "type": "encrypted",
+    "formats": [
+      { "code": 0, "format": "box1" },
+      { "code": 1, "format": "box2" }
+    ]
+  },
+  {
+    "code": 6,
+    "type": "generic",
+    "formats": [
+      { "code": 0, "format": "UTF8 string" },
+      { "code": 1, "format": "boolean" },
+      { "code": 2, "format": "nil" }
+    ]
+  }
+]

--- a/index.js
+++ b/index.js
@@ -4,36 +4,59 @@
 
 const TYPES = require('./bfe.json')
 
-const FEED = TYPES[0]
+function convertTypesToNamedTypes(TYPES) {
+  const NAMED_TYPES = {}
+
+  function convertFormats(type) {
+    const formats = {}
+    for (let i = 0; i < type.formats.length; ++i) {
+      const format = type.formats[i]
+      formats[format.format] = format
+    }
+
+    return Object.assign(type, { formats })
+  }
+
+  for (let i = 0; i < TYPES.length; ++i) {
+    const type = TYPES[i]
+    NAMED_TYPES[type.type] = convertFormats(type)
+  }
+
+  return NAMED_TYPES
+}
+
+const NAMED_TYPES = convertTypesToNamedTypes(TYPES)
+
+const FEED = NAMED_TYPES['feed']
 const FEED_T = Buffer.from([FEED.code])
-const CLASSIC_FEED_TF = Buffer.from([FEED.code, FEED.formats[0].code])
-const GABBYGR_FEED_TF = Buffer.from([FEED.code, FEED.formats[1].code])
-const BENDYBT_FEED_TF = Buffer.from([FEED.code, FEED.formats[3].code])
+const CLASSIC_FEED_TF = Buffer.from([FEED.code, FEED.formats['ssb/classic'].code])
+const GABBYGR_FEED_TF = Buffer.from([FEED.code, FEED.formats['ssb/gabby-grove'].code])
+const BENDYBT_FEED_TF = Buffer.from([FEED.code, FEED.formats['ssb/bendy-butt'].code])
 
-const MSG = TYPES[1]
+const MSG = NAMED_TYPES['msg']
 const MSG_T = Buffer.from([MSG.code])
-const CLASSIC_MSG_TF = Buffer.from([MSG.code, MSG.formats[0].code])
-const GABBYGR_MSG_TF = Buffer.from([MSG.code, MSG.formats[1].code])
-const BENDYBT_MSG_TF = Buffer.from([MSG.code, MSG.formats[4].code])
+const CLASSIC_MSG_TF = Buffer.from([MSG.code, MSG.formats['ssb/classic'].code])
+const GABBYGR_MSG_TF = Buffer.from([MSG.code, MSG.formats['ssb/gabby-grove'].code])
+const BENDYBT_MSG_TF = Buffer.from([MSG.code, MSG.formats['ssb/bendy-butt'].code])
 
-const BLOB = TYPES[2]
+const BLOB = NAMED_TYPES['blob']
 const BLOB_T = Buffer.from([BLOB.code])
-const CLASSIC_BLOB_TF = Buffer.from([BLOB.code, BLOB.formats[0].code])
+const CLASSIC_BLOB_TF = Buffer.from([BLOB.code, BLOB.formats['ssb/classic'].code])
 
-const SIGNATURE = TYPES[4]
-const SIGNATURE_TF = Buffer.from([SIGNATURE.code, SIGNATURE.formats[0].code])
+const SIGNATURE = NAMED_TYPES['signature']
+const SIGNATURE_TF = Buffer.from([SIGNATURE.code, SIGNATURE.formats['ed25519'].code])
 
-const BOX = TYPES[5]
+const BOX = NAMED_TYPES['encrypted']
 const BOX_T = Buffer.from([BOX.code])
-const BOX1_TF = Buffer.from([BOX.code, BOX.formats[0].code])
-const BOX2_TF = Buffer.from([BOX.code, BOX.formats[1].code])
+const BOX1_TF = Buffer.from([BOX.code, BOX.formats['box1'].code])
+const BOX2_TF = Buffer.from([BOX.code, BOX.formats['box2'].code])
 
-const GENERIC = TYPES[6]
-const STRING_TF = Buffer.from([GENERIC.code, GENERIC.formats[0].code])
-const BOOL_TF = Buffer.from([GENERIC.code, GENERIC.formats[1].code])
+const GENERIC = NAMED_TYPES['generic']
+const STRING_TF = Buffer.from([GENERIC.code, GENERIC.formats['UTF8 string'].code])
+const BOOL_TF = Buffer.from([GENERIC.code, GENERIC.formats['boolean'].code])
 const BOOL_TRUE = Buffer.from([1])
 const BOOL_FALSE = Buffer.from([0])
-const NIL_TF = Buffer.from([GENERIC.code, GENERIC.formats[2].code])
+const NIL_TF = Buffer.from([GENERIC.code, GENERIC.formats['nil'].code])
 const NIL_TFD = NIL_TF
 
 const encoder = {
@@ -244,5 +267,6 @@ function decode(input) {
 module.exports = {
   encode,
   decode,
-  bfeTypes: TYPES
+  bfeTypes: TYPES,
+  bfeNamedTypes: NAMED_TYPES
 }

--- a/index.js
+++ b/index.js
@@ -2,30 +2,38 @@
 // file uses "T" to mean "Type byte", "TF" to mean "Type byte and Format byte"
 // and "D" to mean "Data bytes".
 
-const FEED_T = Buffer.from([0])
-const CLASSIC_FEED_TF = Buffer.from([0, 0])
-const GABBYGR_FEED_TF = Buffer.from([0, 1])
-const BENDYBT_FEED_TF = Buffer.from([0, 3])
+const TYPES = require('./bfe.json')
 
-const MSG_T = Buffer.from([1])
-const CLASSIC_MSG_TF = Buffer.from([1, 0])
-const GABBYGR_MSG_TF = Buffer.from([1, 1])
-const BENDYBT_MSG_TF = Buffer.from([1, 4])
+const FEED = TYPES[0]
+const FEED_T = Buffer.from([FEED.code])
+const CLASSIC_FEED_TF = Buffer.from([FEED.code, FEED.formats[0].code])
+const GABBYGR_FEED_TF = Buffer.from([FEED.code, FEED.formats[1].code])
+const BENDYBT_FEED_TF = Buffer.from([FEED.code, FEED.formats[3].code])
 
-const BLOB_T = Buffer.from([2])
-const CLASSIC_BLOB_TF = Buffer.from([2, 0])
+const MSG = TYPES[1]
+const MSG_T = Buffer.from([MSG.code])
+const CLASSIC_MSG_TF = Buffer.from([MSG.code, MSG.formats[0].code])
+const GABBYGR_MSG_TF = Buffer.from([MSG.code, MSG.formats[1].code])
+const BENDYBT_MSG_TF = Buffer.from([MSG.code, MSG.formats[4].code])
 
-const SIGNATURE_TF = Buffer.from([4, 0])
+const BLOB = TYPES[2]
+const BLOB_T = Buffer.from([BLOB.code])
+const CLASSIC_BLOB_TF = Buffer.from([BLOB.code, BLOB.formats[0].code])
 
-const BOX_T = Buffer.from([5])
-const BOX1_TF = Buffer.from([5, 0])
-const BOX2_TF = Buffer.from([5, 1])
+const SIGNATURE = TYPES[4]
+const SIGNATURE_TF = Buffer.from([SIGNATURE.code, SIGNATURE.formats[0].code])
 
-const STRING_TF = Buffer.from([6, 0])
-const BOOL_TF = Buffer.from([6, 1])
+const BOX = TYPES[5]
+const BOX_T = Buffer.from([BOX.code])
+const BOX1_TF = Buffer.from([BOX.code, BOX.formats[0].code])
+const BOX2_TF = Buffer.from([BOX.code, BOX.formats[1].code])
+
+const GENERIC = TYPES[6]
+const STRING_TF = Buffer.from([GENERIC.code, GENERIC.formats[0].code])
+const BOOL_TF = Buffer.from([GENERIC.code, GENERIC.formats[1].code])
 const BOOL_TRUE = Buffer.from([1])
 const BOOL_FALSE = Buffer.from([0])
-const NIL_TF = Buffer.from([6, 2])
+const NIL_TF = Buffer.from([GENERIC.code, GENERIC.formats[2].code])
 const NIL_TFD = NIL_TF
 
 const encoder = {
@@ -236,4 +244,5 @@ function decode(input) {
 module.exports = {
   encode,
   decode,
+  bfeTypes: TYPES
 }


### PR DESCRIPTION
This moves over bfe.json from https://github.com/ssb-ngi-pointer/ssb-binary-field-encodings-spec and uses it for constants. Also exports bfeTypes so that it's easy for other libraries to use.