### PR TITLE
encode/decode arbitrary buffers with prefix 0x0603

### DIFF
--- a/bfe.json
+++ b/bfe.json
@@ -56,7 +56,8 @@
     "formats": [
       { "code": 0, "format": "UTF8 string" },
       { "code": 1, "format": "boolean" },
-      { "code": 2, "format": "nil" }
+      { "code": 2, "format": "nil" },
+      { "code": 3, "format": "arbitrary bytes" }
     ]
   }
 ]

--- a/test/06-generic.js
+++ b/test/06-generic.js
@@ -10,11 +10,11 @@ tape('06 generic type', function (t) {
     '@mention',
     '%done',
     '&co',
+    Buffer.from([3, 2, 1]),
 
     /* not covered by BFE */
     100,
     0,
-    Buffer.from([3, 2, 1]),
   ]
 
   const encoded = bfe.encode(values)
@@ -23,15 +23,14 @@ tape('06 generic type', function (t) {
   t.deepEqual(encoded[1], Buffer.from([6, 1, 0]), 'false')
   t.deepEqual(encoded[2], Buffer.from([6, 2]), 'null')
   t.deepEqual(encoded[3].slice(0, 2), Buffer.from([6, 0]), 'string')
-
   t.deepEqual(encoded[4].slice(0, 2), Buffer.from([6, 0]), '@string')
   t.deepEqual(encoded[5].slice(0, 2), Buffer.from([6, 0]), '%string')
   t.deepEqual(encoded[6].slice(0, 2), Buffer.from([6, 0]), '&string')
+  t.deepEqual(encoded[7].slice(0, 2), Buffer.from([6, 3]), 'arbitrary bytes')
 
   /* not covered by BFE */
-  t.equal(encoded[7], 100, 'numbers not encoded')
-  t.equal(encoded[8], 0, 'falsy number as an array item') // isn't this the same as "numbers no encoded"?
-  t.deepEqual(encoded[9], Buffer.from([3, 2, 1]), 'buffer untouched')
+  t.equal(encoded[8], 100, 'numbers not encoded')
+  t.equal(encoded[9], 0, 'falsy number as an array item') // isn't this the same as "numbers no encoded"?
 
   t.deepEquals(bfe.decode(encoded), values, 'decode works')
   t.end()


### PR DESCRIPTION
Fixes issue #19. The spec was updated with https://github.com/ssb-ngi-pointer/ssb-binary-field-encodings-spec/pull/10