### PR TITLE
refactor to use bfe.json for sigil/suffix checks etc

### DIFF
--- a/bfe.json
+++ b/bfe.json
@@ -59,7 +59,8 @@
     "formats": [
       { "code": 0, "format": "UTF8 string" },
       { "code": 1, "format": "boolean" },
-      { "code": 2, "format": "nil" }
+      { "code": 2, "format": "nil" },
+      { "code": 3, "format": "arbitrary bytes" }
     ]
   }
 ]

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const definitions = require('./bfe.json')
 const {
   decorateBFE,
   definitionsToDict,
-  findClassicTypeFormat,
+  findTypeFormatForSigilSuffix,
 } = require('./util')
 
 const TYPES = decorateBFE(definitions)
@@ -51,7 +51,7 @@ function encode(input) {
 
   if (typeof input === 'string') {
     /* looks for classic sigil/suffix matches */
-    const { type, format } = findClassicTypeFormat(input, TYPES)
+    const { type, format } = findTypeFormatForSigilSuffix(input, TYPES)
     if (type) {
       if (format) return encoder.sigilSuffix(input, type, format)
       else {

--- a/test/06-generic.js
+++ b/test/06-generic.js
@@ -10,11 +10,11 @@ tape('06 generic type', function (t) {
     '@mention',
     '%done',
     '&co',
+    Buffer.from([3, 2, 1]),
 
     /* not covered by BFE */
     100,
     0,
-    Buffer.from([3, 2, 1]),
   ]
 
   const encoded = bfe.encode(values)
@@ -23,15 +23,14 @@ tape('06 generic type', function (t) {
   t.deepEqual(encoded[1], Buffer.from([6, 1, 0]), 'false')
   t.deepEqual(encoded[2], Buffer.from([6, 2]), 'null')
   t.deepEqual(encoded[3].slice(0, 2), Buffer.from([6, 0]), 'string')
-
   t.deepEqual(encoded[4].slice(0, 2), Buffer.from([6, 0]), '@string')
   t.deepEqual(encoded[5].slice(0, 2), Buffer.from([6, 0]), '%string')
   t.deepEqual(encoded[6].slice(0, 2), Buffer.from([6, 0]), '&string')
+  t.deepEqual(encoded[7].slice(0, 2), Buffer.from([6, 3]), 'buffer')
 
   /* not covered by BFE */
-  t.equal(encoded[7], 100, 'numbers not encoded')
-  t.equal(encoded[8], 0, 'falsy number as an array item') // isn't this the same as "numbers no encoded"?
-  t.deepEqual(encoded[9], Buffer.from([3, 2, 1]), 'buffer untouched')
+  t.equal(encoded[8], 100, 'numbers not encoded')
+  t.equal(encoded[9], 0, 'falsy number not encoded')
 
   t.deepEquals(bfe.decode(encoded.slice()), values.slice(), 'decode works')
   t.end()

--- a/test/06-generic.js
+++ b/test/06-generic.js
@@ -33,12 +33,6 @@ tape('06 generic type', function (t) {
   t.equal(encoded[8], 0, 'falsy number as an array item') // isn't this the same as "numbers no encoded"?
   t.deepEqual(encoded[9], Buffer.from([3, 2, 1]), 'buffer untouched')
 
-  // WARNING! a buffer is encoded as a buffer, which can lead to strange behaviour on decoding!!
-  //
-  t.deepEquals(
-    bfe.decode(encoded.slice(0, encoded.length - 1)),
-    values.slice(0, encoded.length - 1),
-    'decode works'
-  )
+  t.deepEquals(bfe.decode(encoded.slice()), values.slice(), 'decode works')
   t.end()
 })

--- a/util.js
+++ b/util.js
@@ -1,12 +1,6 @@
 const IsCanonicalBase64 = require('is-canonical-base64')
 const { isFeedType, isMsgType, isBlobType } = require('ssb-ref')
 
-module.exports = {
-  decorateBFE,
-  findClassicTypeFormat,
-  definitionsToDict,
-}
-
 const encryptedTypeRegex = IsCanonicalBase64('', '\\.box\\d*')
 const sigTypeRegex = IsCanonicalBase64('', '\\.sig\\.[a-zA-Z0-9]+')
 
@@ -41,7 +35,7 @@ function decorateBFE(types) {
   })
 }
 
-function findClassicTypeFormat(input, types) {
+function findTypeFormatForSigilSuffix(input, types) {
   // NOTE tests guarentee that sigil is unique across types
   let type
   let format
@@ -81,4 +75,10 @@ function definitionsToDict(types) {
   }
 
   return NAMED_TYPES
+}
+
+module.exports = {
+  decorateBFE,
+  findTypeFormatForSigilSuffix,
+  definitionsToDict,
 }

--- a/util.js
+++ b/util.js
@@ -1,5 +1,67 @@
+const IsCanonicalBase64 = require('is-canonical-base64')
+const { isFeedType, isMsgType, isBlobType } = require('ssb-ref')
+
 module.exports = {
+  decorateBFE,
+  findClassicTypeFormat,
   definitionsToDict,
+}
+
+const encryptedTypeRegex = IsCanonicalBase64('', '\\.box\\d*')
+const sigTypeRegex = IsCanonicalBase64('', '\\.sig\\.[a-zA-Z0-9]+')
+
+const isEncryptedType = (input) => encryptedTypeRegex.test(input)
+const isSigType = (input) => sigTypeRegex.test(input)
+
+function decorateBFE(types) {
+  const sigilSuffixRegexp = (type, format) => {
+    if (!type.sigil && !format.suffix) return
+
+    return IsCanonicalBase64(
+      type.sigil || '',
+      (format.suffix && format.suffix.replace('.', '\\.')) || '',
+      format.key_length
+    )
+    // NOTE this assumes all sigil / suffic encodings are base64
+  }
+
+  return types.map((type) => {
+    return {
+      ...type,
+      code: Buffer.from([type.code]),
+      formats: type.formats.map((format) => {
+        return {
+          ...format,
+          code: Buffer.from([format.code]),
+          // TFCode: Buffer.from([type.code, format.code]),
+          sigilSuffixRegexp: sigilSuffixRegexp(type, format),
+        }
+      }),
+    }
+  })
+}
+
+function findClassicTypeFormat(input, types) {
+  // NOTE tests guarentee that sigil is unique across types
+  let type
+  let format
+  if (typeof input !== 'string') return { type, format }
+
+  if (isFeedType(input)) type = types[0]
+  else if (isMsgType(input)) type = types[1]
+  else if (isBlobType(input)) type = types[2]
+  else if (isEncryptedType(input)) type = types[5]
+  else if (isSigType(input)) type = types[4]
+  // first regexp match to narrow type
+
+  if (type) {
+    format = type.formats.find((format) => format.sigilSuffixRegexp.test(input))
+    // second regexp check to be 100% sure of match
+
+    return { type, format }
+  }
+
+  return { type, format }
 }
 
 function definitionsToDict(types) {


### PR DESCRIPTION
This PR:
- changes how encoding happens - shifting it to use `bfe.json` as source of truth for sigil/ suffix checks
- creates custom regex matchers to ensure type/format matching with sigil/suffix strings
    - NOTE - this currently assumes data content of strings is base64 encoded (which is currently a safe assumption)