### PR TITLE
add support for ssb-uri encode/decode

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,20 +34,26 @@ const encoder = {
   },
 
   ssbURI(input) {
-    let [type, format, data = ''] = new URL(input).pathname.split('/')
+    const [typeName, formatName, data = ''] = new URL(input).pathname.split('/')
 
-    type = NAMED_TYPES[type]
-    format = type.formats[format]
-    data = URIDataToBuffer(data)
-
-    if (format.data_length && data.length !== format.data_length) {
+    const type = NAMED_TYPES[typeName]
+    if (!type) return encoder.string(input)
+    const format = type.formats[formatName]
+    if (!format) {
       throw new Error(
-        `expected data to be length ${format.data_length}, but found ${data.length}`
+        `No encoder for type=${typeName} format=${formatName} for SSB URI ${input}`
+      )
+    }
+    const d = URIDataToBuffer(data)
+
+    if (format.data_length && d.length !== format.data_length) {
+      throw new Error(
+        `expected data to be length ${format.data_length}, but found ${d.length}`
       )
     }
 
     const tf = Buffer.from([type.code, format.code])
-    return Buffer.concat([tf, data])
+    return Buffer.concat([tf, d])
   },
 
   string(input) {

--- a/test/03-encryption-key.js
+++ b/test/03-encryption-key.js
@@ -1,0 +1,30 @@
+const tape = require('tape')
+const crypto = require('crypto')
+const bfe = require('../')
+
+tape('03 encryption key', function (t) {
+  const key = crypto.randomBytes(32)
+
+  const values = [
+    'ssb:diffie-hellman/curve25519/' +
+      key.toString('base64').replace(/\+/g, '-').replace(/\//g, '_'),
+    'ssb:diffie-hellman/curve25519/' +
+      key.toString('base64').replace(/\+/g, '-').replace(/\//g, '_') +
+      '?render=thread',
+  ]
+  const valuesLessQueries = values.map((value) => value.replace(/\?.*$/, ''))
+  const encoded = bfe.encode(values)
+
+  t.deepEqual(encoded[0].slice(0, 2), Buffer.from([3, 0]), 'detected key')
+  t.deepEqual(encoded[0].slice(2), key, 'decoded key data correctly')
+
+  t.deepEqual(bfe.decode(encoded), valuesLessQueries, 'properly decoded')
+
+  /* unhappy paths */
+  t.throws(
+    () => bfe.decode(Buffer.from([3, 200, 21])), // type 200 DNE
+    'unknown signature type decode throws'
+  )
+
+  t.end()
+})

--- a/test/03-encryption-key.js
+++ b/test/03-encryption-key.js
@@ -1,16 +1,14 @@
 const tape = require('tape')
 const crypto = require('crypto')
 const bfe = require('../')
+const { bufferToURIData } = require('../util')
 
 tape('03 encryption key', function (t) {
   const key = crypto.randomBytes(32)
 
   const values = [
-    'ssb:diffie-hellman/curve25519/' +
-      key.toString('base64').replace(/\+/g, '-').replace(/\//g, '_'),
-    'ssb:diffie-hellman/curve25519/' +
-      key.toString('base64').replace(/\+/g, '-').replace(/\//g, '_') +
-      '?render=thread',
+    'ssb:diffie-hellman/curve25519/' + bufferToURIData(key),
+    'ssb:diffie-hellman/curve25519/' + bufferToURIData(key) + '?render=thread',
   ]
   const valuesLessQueries = values.map((value) => value.replace(/\?.*$/, ''))
   const encoded = bfe.encode(values)

--- a/test/ssb-uri.test.js
+++ b/test/ssb-uri.test.js
@@ -9,5 +9,17 @@ tape('ssb-uri encoding', function (t) {
     'ssb:feed/bamboo/' + bufferToURIData(crypto.randomBytes(13))
   t.throws(() => bfe.encode(wrongDataLength), 'incorrect data length')
 
+  const bfelessURI =
+    'ssb:address/multiserver?multiserverAddress=net%3Awx.larpa.net%3A8008~shs%3ADTNmX%2B4SjsgZ7xyDh5xxmNtFqa6pWi5Qtw7cE8aR9TQ%3D'
+  const encoded1 = bfe.encode(bfelessURI)
+  t.deepEqual(
+    encoded1.slice(0, 2),
+    Buffer.from([6, 0]),
+    'unknown URIs get encoded as BFE strings'
+  )
+
+  const weirdURI = 'ssb:feed/joke/invalidCanonicalSSBURI'
+  t.throws(() => bfe.encode(weirdURI), 'SSB URI with unknown format throws')
+
   t.end()
 })

--- a/test/ssb-uri.test.js
+++ b/test/ssb-uri.test.js
@@ -1,0 +1,13 @@
+const tape = require('tape')
+const crypto = require('crypto')
+const bfe = require('../')
+const { bufferToURIData } = require('../util')
+
+tape('ssb-uri encoding', function (t) {
+  /* unhappy paths */
+  const wrongDataLength =
+    'ssb:feed/bamboo/' + bufferToURIData(crypto.randomBytes(13))
+  t.throws(() => bfe.encode(wrongDataLength), 'incorrect data length')
+
+  t.end()
+})

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -3,9 +3,7 @@ const test = require('tape')
 const { bufferToURIData, URIDataToBuffer } = require('../util')
 
 test('util (ssb-uri methods)', (t) => {
-  const uriData = '8LFJ/YVGqcypcXXf0KlHXJsB/0vC9ynu/DxJKX8jlC0='
-    .replace(/\//g, '_')
-    .replace(/\+/g, '-')
+  const uriData = 'g3hPVPDEO1Aj_uPl0-J2NlhFB2bbFLIHlty-YuqFZ3w='
   const buffer = URIDataToBuffer(uriData)
 
   t.deepEqual(

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -1,0 +1,18 @@
+const test = require('tape')
+
+const { bufferToURIData, URIDataToBuffer } = require('../util')
+
+test('util (ssb-uri methods)', (t) => {
+  const uriData = '8LFJ/YVGqcypcXXf0KlHXJsB/0vC9ynu/DxJKX8jlC0='
+    .replace(/\//g, '_')
+    .replace(/\+/g, '-')
+  const buffer = URIDataToBuffer(uriData)
+
+  t.deepEqual(
+    bufferToURIData(buffer),
+    uriData,
+    'bufferToURIData and URIDataToBuffer are inverses'
+  )
+
+  t.end()
+})

--- a/util.js
+++ b/util.js
@@ -81,4 +81,10 @@ module.exports = {
   decorateBFE,
   findTypeFormatForSigilSuffix,
   definitionsToDict,
+  bufferToURIData(buf) {
+    return buf.toString('base64').replace(/\+/g, '-').replace(/\//g, '_')
+  },
+  URIDataToBuffer(str) {
+    return Buffer.from(str.replace(/-/g, '+').replace(/_/g, '/'), 'base64')
+  },
 }


### PR DESCRIPTION
## context

mix is building po-box things out, and we're wanting to add support for URIs (since we're not doing more sigils)

this adds:
- encoding
    - will spot things starting with `ssb:`, and use `bfe.json` names to try and find type/ format
    - throw if no type/ format found
    - throw if the format has a `data_length` and the URI has the wrong length of data coming in

- decoding
    - if it's not a sigil/suffix type/format, and it's not a generic, then it outputs an ssb-uri
    - i.e. it's basically a new fallback (instead of throwing) if a decoder was not defined