### PR TITLE
support encoding/decoding SSB URIs semantically

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ const BOOL_FALSE = Buffer.from([0])
 const encoder = {
   sigilSuffix(input, type, format) {
     let data = input
-    if (type.sigil) data = data.slice(1)
+    if (format.sigil) data = data.slice(1)
     if (format.suffix) data = data.slice(0, -format.suffix.length)
 
     return Buffer.concat([type.code, format.code, Buffer.from(data, 'base64')])
@@ -102,7 +102,7 @@ function encode(input) {
       if (format) return encoder.sigilSuffix(input, type, format)
       else {
         throw new Error(
-          `No encoder for type=${type} format=? for string ${input}`
+          `No encoder for type=${type.type} format=? for string ${input}`
         )
       }
     }
@@ -153,7 +153,7 @@ const decoder = {
   },
   sigilSuffix(input, type, format) {
     const d = input.slice(2)
-    return [type.sigil || '', d.toString('base64'), format.suffix || ''].join(
+    return [format.sigil || '', d.toString('base64'), format.suffix || ''].join(
       ''
     )
   },
@@ -209,7 +209,7 @@ function decode(input) {
       const f = input.slice(1, 2)
       const format = type.formats.find((format) => format.code.equals(f))
       if (format) {
-        if (type.sigil || format.suffix) {
+        if (format.sigil || format.suffix) {
           return decoder.sigilSuffix(input, type, format)
         } else {
           return decoder.ssbURI(input, type, format)

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "is-canonical-base64": "^1.1.1",
-    "ssb-bfe-spec": "^0.1.1",
+    "ssb-bfe-spec": "github:ssb-ngi-pointer/ssb-bfe-spec#support-ssb-uris",
     "ssb-ref": "^2.16.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "is-canonical-base64": "^1.1.1",
-    "ssb-bfe-spec": "github:ssb-ngi-pointer/ssb-bfe-spec#support-ssb-uris",
+    "ssb-bfe-spec": "~0.2.0",
     "ssb-ref": "^2.16.0"
   },
   "devDependencies": {

--- a/test/00-feed.js
+++ b/test/00-feed.js
@@ -6,7 +6,7 @@ const { bfeNamedTypes, bfeTypes } = bfe
 tape('00 feed type', function (t) {
   const values = [
     '@6CAxOI3f+LUOVrbAl0IemqiS7ATpQvr9Mdw9LC4+Uv0=.ed25519', // classic
-    '@6CAxOI3f+LUOVrbAl0IemqiS7ATpQvr9Mdw9LC4+Uv0=.bbfeed-v1', // bendy-butt
+    'ssb:feed/bendybutt-v1/6CAxOI3f-LUOVrbAl0IemqiS7ATpQvr9Mdw9LC4-Uv0=', // bendy-butt
   ]
 
   const encoded = bfe.encode(values)

--- a/test/01-msg.js
+++ b/test/01-msg.js
@@ -4,7 +4,7 @@ const bfe = require('../')
 tape('01 msg type', function (t) {
   const values = [
     '%HZVnEzm0NgoSVfG0Hx4gMFbMMHhFvhJsG2zK/pijYII=.sha256', // classic
-    '%HZVnEzm0NgoSVfG0Hx4gMFbMMHhFvhJsG2zK/pijYII=.bbmsg-v1', // bendy-butt
+    'ssb:message/bendybutt-v1/HZVnEzm0NgoSVfG0Hx4gMFbMMHhFvhJsG2zK_pijYII=', // bendy-butt
   ]
 
   const encoded = bfe.encode(values)

--- a/test/toTF.js
+++ b/test/toTF.js
@@ -2,7 +2,7 @@ const tape = require('tape')
 const { toTF } = require('../')
 
 tape('toTF() happy cases', function (t) {
-  t.equals(toTF('msg', 'bamboo').toString('hex'), '0103', 'bamboo msg')
+  t.equals(toTF('message', 'bamboo').toString('hex'), '0103', 'bamboo msg')
   t.equals(toTF('generic', 'string-UTF8').toString('hex'), '0600', 'string')
   t.equals(toTF('generic', 'boolean').toString('hex'), '0601', 'boolean')
   t.equals(toTF('generic', 'nil').toString('hex'), '0602', 'nil')
@@ -14,8 +14,10 @@ tape('toTF() sad cases', function (t) {
   t.throws(() => {
     toTF('NONSENSE', 'bamboo')
   }, /Unknown type/i)
+
   t.throws(() => {
-    toTF('msg', 'NONSENSE')
+    toTF('message', 'NONSENSE')
   }, /Unknown format/i)
+
   t.end()
 })

--- a/util.js
+++ b/util.js
@@ -9,10 +9,10 @@ const isSigType = (input) => sigTypeRegex.test(input)
 
 function decorateBFE(types) {
   const sigilSuffixRegexp = (type, format) => {
-    if (!type.sigil && !format.suffix) return
+    if (!format.sigil && !format.suffix) return
 
     return IsCanonicalBase64(
-      type.sigil || '',
+      format.sigil || '',
       (format.suffix && format.suffix.replace('.', '\\.')) || '',
       format.key_length
     )


### PR DESCRIPTION
- [x] Code reviews
- [x] Pending on https://github.com/ssb-ngi-pointer/ssb-meta-feed-spec/pull/25 merged first
- [x] Pending on https://github.com/ssb-ngi-pointer/ssb-bfe-spec/pull/20 merged first
- [x] Pending on a new version of ssb-bfe-spec released on npm and updated here