### PR TITLE
Graceful handling of invalid sigil suffix

### DIFF
--- a/test/00-feed.js
+++ b/test/00-feed.js
@@ -7,12 +7,20 @@ tape('00 feed type', function (t) {
   const values = [
     '@6CAxOI3f+LUOVrbAl0IemqiS7ATpQvr9Mdw9LC4+Uv0=.ed25519', // classic
     'ssb:feed/bendybutt-v1/6CAxOI3f-LUOVrbAl0IemqiS7ATpQvr9Mdw9LC4-Uv0=', // bendy-butt
+    'ssb:feed/gabby-grove/FY5OG311W4j_KPh8H9B2MZt4WSziy_p-ABkKERJdujQ=', // gabby-grove
+    '@6CAxOI3f+LUOVrbAl0IemqiS7ATpQvr9Mdw9LC4+Uv0=.ggfeed-v1', // gabby-grove (sigil)
   ]
 
   const encoded = bfe.encode(values)
 
   t.deepEquals(encoded[0].slice(0, 2), Buffer.from([0, 0]), 'classic feed')
   t.deepEquals(encoded[1].slice(0, 2), Buffer.from([0, 3]), 'bendy feed')
+  t.deepEquals(encoded[2].slice(0, 2), Buffer.from([0, 1]), 'gabby grove')
+  t.deepEquals(
+    encoded[3].slice(0, 2),
+    Buffer.from([0, 1]),
+    'gabby grove (sigil-link)'
+  )
 
   t.deepEquals(bfe.decode(encoded), values, 'decode works')
 

--- a/test/00-feed.js
+++ b/test/00-feed.js
@@ -8,7 +8,6 @@ tape('00 feed type', function (t) {
     '@6CAxOI3f+LUOVrbAl0IemqiS7ATpQvr9Mdw9LC4+Uv0=.ed25519', // classic
     'ssb:feed/bendybutt-v1/6CAxOI3f-LUOVrbAl0IemqiS7ATpQvr9Mdw9LC4-Uv0=', // bendy-butt
     'ssb:feed/gabby-grove/FY5OG311W4j_KPh8H9B2MZt4WSziy_p-ABkKERJdujQ=', // gabby-grove
-    '@6CAxOI3f+LUOVrbAl0IemqiS7ATpQvr9Mdw9LC4+Uv0=.ggfeed-v1', // gabby-grove (sigil)
   ]
 
   const encoded = bfe.encode(values)
@@ -16,17 +15,18 @@ tape('00 feed type', function (t) {
   t.deepEquals(encoded[0].slice(0, 2), Buffer.from([0, 0]), 'classic feed')
   t.deepEquals(encoded[1].slice(0, 2), Buffer.from([0, 3]), 'bendy feed')
   t.deepEquals(encoded[2].slice(0, 2), Buffer.from([0, 1]), 'gabby grove')
-  t.deepEquals(
-    encoded[3].slice(0, 2),
-    Buffer.from([0, 1]),
-    'gabby grove (sigil-link)'
-  )
 
   t.deepEquals(bfe.decode(encoded), values, 'decode works')
 
   /* unhappy paths */
   const unknownFeedId = '@' + Buffer.from('dog').toString('base64') + '.dog255'
-  t.throws(() => bfe.encode(unknownFeedId), 'unknown feedId encode throws')
+  t.throws(
+    () => {
+      bfe.encode(unknownFeedId)
+    },
+    { message: 'No encoder for type=feed format=? for string @ZG9n.dog255' },
+    'unknown feedId encode throws'
+  )
   t.throws(
     () => bfe.decode(Buffer.from([0, 200, 21])), // type 200 DNE
     'unknown feed type decode throws'

--- a/test/00-feed.js
+++ b/test/00-feed.js
@@ -25,8 +25,21 @@ tape('00 feed type', function (t) {
       bfe.encode(unknownFeedId)
     },
     { message: 'No encoder for type=feed format=? for string @ZG9n.dog255' },
-    'unknown feedId encode throws'
+    'unknown feedId encode throws (.dog225)'
   )
+
+  const gabbyFeedId = '@6CAxOI3f+LUOVrbAl0IemqiS7ATpQvr9Mdw9LC4+Uv0=.ggfeed-v1'
+  t.throws(
+    () => {
+      bfe.encode(gabbyFeedId)
+    },
+    {
+      message:
+        'No encoder for type=feed format=? for string @6CAxOI3f+LUOVrbAl0IemqiS7ATpQvr9Mdw9LC4+Uv0=.ggfeed-v1',
+    },
+    'unknown feedId encode throws (.ggfeed-v1)'
+  )
+
   t.throws(
     () => bfe.decode(Buffer.from([0, 200, 21])), // type 200 DNE
     'unknown feed type decode throws'

--- a/util.js
+++ b/util.js
@@ -49,8 +49,14 @@ function findTypeFormatForSigilSuffix(input, types) {
   // first regexp match to narrow type
 
   if (type) {
-    format = type.formats.find((format) => format.sigilSuffixRegexp.test(input))
-    // second regexp check to be 100% sure of match
+    try {
+      format = type.formats.find((format) =>
+        format.sigilSuffixRegexp.test(input)
+      )
+      // second regexp check to be 100% sure of match
+    } catch {
+      format = undefined
+    }
 
     return { type, format }
   }


### PR DESCRIPTION
Passing an SSB ref with non-classic suffix (e.g. `@6CAxOI3f+LUOVrbAl0IemqiS7ATpQvr9Mdw9LC4+Uv0=.ggfeed-v1`) results in a `TypeError`:

```
/home/glyph/Projects/ngi/ssb-bfe/util.js:52
    format = type.formats.find((format) => format.sigilSuffixRegexp.test(input))
                                                                    ^

TypeError: Cannot read property 'test' of undefined
```

We should rather return `undefined` when no `format` match is found. This will result in a `No encoder for type...` error being returned (L105 in `index.js`) instead of the opaque `TypeError`.