### PR TITLE
Replace key_length with data_length

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
   },
   "dependencies": {
     "is-canonical-base64": "^1.1.1",
-    "ssb-bfe-spec": "~0.3.0",
+    "ssb-bfe-spec": "~0.4.0",
     "ssb-ref": "^2.16.0",
-    "ssb-uri2": "^1.5.1"
+    "ssb-uri2": "^1.5.2"
   },
   "devDependencies": {
     "husky": "^4.3.0",

--- a/util.js
+++ b/util.js
@@ -14,9 +14,9 @@ function decorateBFE(types) {
     return IsCanonicalBase64(
       format.sigil || '',
       (format.suffix && format.suffix.replace('.', '\\.')) || '',
-      format.key_length
+      format.data_length
     )
-    // NOTE this assumes all sigil / suffic encodings are base64
+    // NOTE this assumes all sigil / suffix encodings are base64
   }
 
   return types.map((type) => {


### PR DESCRIPTION
Since we removed `key_length` from the bfe-spec (https://github.com/ssb-ngi-pointer/ssb-bfe-spec/pull/22), this PR replaces `key_length` with `data_length` (a single LOC in `util.js`).

I also bumped two dependencies and fixed a code comment typo.

Tests are passing for me locally.